### PR TITLE
Fallback to an other file

### DIFF
--- a/getfreq.c
+++ b/getfreq.c
@@ -87,7 +87,7 @@ int gf_current(int core)
         {
             debug("Couldn't open '%s'\n", path);
             free(path);
-		    return -1;
+            return -1;
         }
 	}
 


### PR DESCRIPTION
I was getting a FPE when launching trayfreq. Turns out that the file you are reading was not on my system so I falled back to this one instead. (Raw speed value)  Tried to repackage for Archlinux but I coul'nt get the "trayfreq" command so I leave it to you.
(Sorry for formatting. Tried 4 spaces and tabulation. None working ...)
