### PR TITLE
fix: cannot get all governors because the file of scaling_available_governors has a n in the line end

### DIFF
--- a/getgov.c
+++ b/getgov.c
@@ -24,15 +24,10 @@ void gg_init()
 		memset(gov_string, '\0', sizeof(gov_string) );
 		gg_available(i, gov_string, sizeof(gov_string) );
 
-		char* curr = gov_string;
-		char* end_of_curr = g_strstr_len(curr, strlen(curr), " ");
-		while (end_of_curr)
-		{
+		char** list = g_strsplit(g_strstrip(gov_string), " ", -1);
+		for (char** name = list; *name; ++name) {
 			memset(governors[i][total_governors], '\0', 13); /* FIXME magic */
-			memmove(governors[i][total_governors], curr, end_of_curr - curr);
-
-			curr = end_of_curr+1;
-			end_of_curr = g_strstr_len(curr, strlen(curr), " ");
+			memmove(governors[i][total_governors], *name, strlen(*name));
 			total_governors++;
 		}
 	}


### PR DESCRIPTION
The content of file `/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors` is:
```
performance powersave\n
```

So we need handle the `\n` in the line end. But the origin code only handle `\x20`(space), so it would be ignore the last governor name:
```c
		char* curr = gov_string;
		char* end_of_curr = g_strstr_len(curr, strlen(curr), " ");
		while (end_of_curr)
		{
			memset(governors[i][total_governors], '\0', 13); /* FIXME magic */
			memmove(governors[i][total_governors], curr, end_of_curr - curr);

			curr = end_of_curr+1;
			end_of_curr = g_strstr_len(curr, strlen(curr), " ");
			total_governors++;
		}
```

