### PR TITLE
Avoid duplicate definition of global default variables

### DIFF
--- a/defaults.c
+++ b/defaults.c
@@ -3,6 +3,14 @@
 #include <stddef.h>
 #include <stdio.h>
 
+char* DEFAULT_GOV;
+char* DEFAULT_FREQ;
+char* DEFAULT_PROG;
+char* DEFAULT_BAT_GOV;
+char* DEFAULT_AC_GOV;
+bool  DEFAULT_SHOW_BATTERY;
+char  DEFAULT_THEME[1024];
+
 void defaults_init()
 {
 	DEFAULT_GOV				= NULL;

--- a/defaults.h
+++ b/defaults.h
@@ -1,12 +1,12 @@
 #include <stdbool.h>
 
-char* DEFAULT_GOV;
-char* DEFAULT_FREQ;
-char* DEFAULT_PROG;
-char* DEFAULT_BAT_GOV;
-char* DEFAULT_AC_GOV;
-bool  DEFAULT_SHOW_BATTERY;
-char  DEFAULT_THEME[1024];
+extern char* DEFAULT_GOV;
+extern char* DEFAULT_FREQ;
+extern char* DEFAULT_PROG;
+extern char* DEFAULT_BAT_GOV;
+extern char* DEFAULT_AC_GOV;
+extern bool  DEFAULT_SHOW_BATTERY;
+extern char  DEFAULT_THEME[1024];
 
 
 void defaults_init();


### PR DESCRIPTION
With GCC 10 several things changed. One of the things is that
-fno-common is set by default which prevents the code to link cause of multiple
definition issues.
Declared the variables extern and defined them in c-file to avoid the linker error.
Details can be found here: https://gcc.gnu.org/gcc-10/porting_to.html